### PR TITLE
Implement forward compatible Clock-Interface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         }
     ],
     "require": {
-        "php": "^7.0|^8.0"
+        "php": "^7.0|^8.0",
+        "stella-maris/clock": "^0.1.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.0|^8.0",
-        "stella-maris/clock": "^0.1.1"
+        "stella-maris/clock": "^0.1.4"
     },
     "autoload": {
         "psr-4": {

--- a/src/Clock.php
+++ b/src/Clock.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Kreait;
 
 use DateTimeImmutable;
+use StellaMaris\Clock\ClockInterface;
 
-interface Clock
+interface Clock extends ClockInterface
 {
     public function now(): DateTimeImmutable;
 }


### PR DESCRIPTION
The stella-maris/clock package provides an interface based on the currently proposed status of PSR20. Due to the inactivity of the PSR20 working group this is a way to already provide interoperability while still maintaining forward compatibility. When the current status of PSR20 will be released at one point in time the stella-maris/clock package will extend the PSR20 interface so that this package becomes immeadiately PSR20 compatible without any further work necessary. In the long run the stella-maris/clock package will then be marked deprecated so that people can then use the PSR20 provided implementation.

Should the implementation of PSR20 change between now and a possible release then this interface will still exist and a possible implementation will need more code-changes anyhow so this interface will still provide some way of interoperability.